### PR TITLE
update scm-provider to use newest version of jgit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+maven-scm-provider-jgit
+===
+
+This scm provider implementation allows the usage of git with the release and scm plugin without having to install a nativ git client. 
+This implementation uses username and password instead of a public/private keys to authenticate the requests to a remote repository like GitHub.
+
+Configuration
+---
+
+Usage with the `maven-release-plugin`
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.3</version>
+				<configuration>
+					<providerImplementations>
+						<git>jgit</git>
+					</providerImplementations>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.scm</groupId>
+						<artifactId>maven-scm-provider-jgit</artifactId>
+						<version>1.8.1</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+
+Usage with the `maven-scm-plugin`
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-scm-plugin</artifactId>
+				<version>1.8.1</version>
+				<configuration>
+					<providerImplementations>
+						<git>jgit</git>
+					</providerImplementations>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.scm</groupId>
+						<artifactId>maven-scm-provider-jgit</artifactId>
+						<version>${jgit.provider.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			
+Examples
+____
+changelog
+
+	mvn org.apache.maven.plugins:maven-scm-plugin:1.8.1:changelog
+	
+release
+
+	mvn release:prepare release:perform -Dresume=false -Dusername=XXX -Dpassword=XXX
+
+	
+
+			
+			
+Features
+---
+
+this is a brief list of the supported maven-scm-provider-jgit's integration status with regard to some core maven plugins
+
+
+maven-scm-plugin
+---
+
+| goal        | implemented?|
+| ------------- |:-------------:|
+| scm:list | yes | 
+| scm:tag | yes | 
+| scm:bootstrap | no |  
+| scm:export | no |  	
+| scm:update | no |  	
+| scm:status | yes | 
+| scm:edit | no |  	
+| scm:changelog | yes |  	
+| scm:add | yes |  	
+| scm:unedit | no |  	
+| scm:validate | yes |  	
+| scm:branch | yes |  	
+| scm:checkin | yes |  	
+| scm:checkout | yes |  	
+| scm:diff | yes | 
+
+maven-release-plugin
+---
+
+| goal        | implemented?|
+| ------------- |:-------------:|
+| release:clean | yes |  	
+| release:prepare | yes |  	
+| release:rollback | no |  	
+| release:perform | yes |  	
+| release:stage | no |  	
+| release:branch | yes |  	

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.scm</groupId>
     <artifactId>maven-scm-providers-git</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-scm-provider-jgit</artifactId>
@@ -53,26 +53,39 @@
       <scope>test</scope>
     </dependency>
     
-    <dependency>
-        <groupId>org.eclipse.jgit</groupId>
-        <artifactId>jgit-simple</artifactId>
-        <version>0.6.0-SNAPSHOT</version>
-    </dependency>
+	<dependency>
+	    <groupId>org.eclipse.jgit</groupId>
+	    <artifactId>org.eclipse.jgit</artifactId>
+	    <version>2.3.1.201302201838-r</version>
+	</dependency>
   </dependencies>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-maven-plugin</artifactId>
+        <artifactId>plexus-component-metadata</artifactId>
         <executions>
           <execution>
+            <id>create-component-descriptor</id>
+            <phase>generate-resources</phase>
             <goals>
-              <goal>descriptor</goal>
+              <goal>generate-metadata</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
+          </execution>        
+        </executions>        
+      </plugin>      
+<!--       <plugin> -->
+<!--         <groupId>org.codehaus.plexus</groupId> -->
+<!--         <artifactId>plexus-maven-plugin</artifactId> -->
+<!--         <executions> -->
+<!--           <execution> -->
+<!--             <goals> -->
+<!--               <goal>descriptor</goal> -->
+<!--             </goals> -->
+<!--           </execution> -->
+<!--         </executions> -->
+<!--       </plugin>       -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
@@ -26,6 +26,7 @@ import org.apache.maven.scm.provider.git.AbstractGitScmProvider;
 import org.apache.maven.scm.provider.git.command.GitCommand;
 import org.apache.maven.scm.provider.git.command.info.GitInfoItem;
 import org.apache.maven.scm.provider.git.jgit.command.add.JGitAddCommand;
+import org.apache.maven.scm.provider.git.jgit.command.branch.JGitBranchCommand;
 import org.apache.maven.scm.provider.git.jgit.command.changelog.JGitChangeLogCommand;
 import org.apache.maven.scm.provider.git.jgit.command.checkin.JGitCheckInCommand;
 import org.apache.maven.scm.provider.git.jgit.command.checkout.JGitCheckOutCommand;
@@ -52,7 +53,7 @@ public class JGitScmProvider
     /** {@inheritDoc} */
     protected GitCommand getBranchCommand()
     {
-    	throw new UnsupportedOperationException("getBranchCommand");
+    	return new JGitBranchCommand();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
@@ -30,6 +30,7 @@ import org.apache.maven.scm.provider.git.jgit.command.branch.JGitBranchCommand;
 import org.apache.maven.scm.provider.git.jgit.command.changelog.JGitChangeLogCommand;
 import org.apache.maven.scm.provider.git.jgit.command.checkin.JGitCheckInCommand;
 import org.apache.maven.scm.provider.git.jgit.command.checkout.JGitCheckOutCommand;
+import org.apache.maven.scm.provider.git.jgit.command.diff.JGitDiffCommand;
 import org.apache.maven.scm.provider.git.jgit.command.status.JGitStatusCommand;
 import org.apache.maven.scm.provider.git.jgit.command.tag.JGitTagCommand;
 import org.apache.maven.scm.repository.ScmRepositoryException;
@@ -77,7 +78,7 @@ public class JGitScmProvider
     /** {@inheritDoc} */
     protected GitCommand getDiffCommand()
     {
-    	throw new UnsupportedOperationException("getDiffCommand");
+    	return new JGitDiffCommand();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
@@ -40,6 +40,7 @@ import org.apache.maven.scm.repository.ScmRepositoryException;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
+ * @author Dominik Bartholdi (imod)
  * @version $Id: JGitScmProvider.java 894145 2009-12-28 10:13:39Z struberg $
  * @plexus.component role="org.apache.maven.scm.provider.ScmProvider" role-hint="jgit"
  */

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
@@ -21,10 +21,10 @@ package org.apache.maven.scm.provider.git.jgit;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.command.info.InfoScmResult;
 import org.apache.maven.scm.provider.git.AbstractGitScmProvider;
 import org.apache.maven.scm.provider.git.command.GitCommand;
 import org.apache.maven.scm.provider.git.command.info.GitInfoItem;
-import org.apache.maven.scm.provider.git.command.info.GitInfoScmResult;
 import org.apache.maven.scm.provider.git.jgit.command.add.JGitAddCommand;
 import org.apache.maven.scm.provider.git.jgit.command.changelog.JGitChangeLogCommand;
 import org.apache.maven.scm.provider.git.jgit.command.checkin.JGitCheckInCommand;
@@ -52,7 +52,7 @@ public class JGitScmProvider
     /** {@inheritDoc} */
     protected GitCommand getBranchCommand()
     {
-        return null;
+    	throw new UnsupportedOperationException("getBranchCommand");
     }
 
     /** {@inheritDoc} */
@@ -76,19 +76,19 @@ public class JGitScmProvider
     /** {@inheritDoc} */
     protected GitCommand getDiffCommand()
     {
-        return null;
+    	throw new UnsupportedOperationException("getDiffCommand");
     }
 
     /** {@inheritDoc} */
     protected GitCommand getExportCommand()
     {
-        return null; //X TODO
+    	throw new UnsupportedOperationException("getExportCommand");
     }
 
     /** {@inheritDoc} */
     protected GitCommand getRemoveCommand()
     {
-        return null;
+    	throw new UnsupportedOperationException("getRemoveCommand");
     }
 
     /** {@inheritDoc} */
@@ -106,19 +106,19 @@ public class JGitScmProvider
     /** {@inheritDoc} */
     protected GitCommand getUpdateCommand()
     {
-        return null;
+    	throw new UnsupportedOperationException("getUpdateCommand");
     }
 
     /** {@inheritDoc} */
     protected GitCommand getListCommand()
     {
-        return null;
+    	throw new UnsupportedOperationException("getListCommand");
     }
 
     /** {@inheritDoc} */
     public GitCommand getInfoCommand()
     {
-        return null; //X TODO
+    	throw new UnsupportedOperationException("getInfoCommand");
     }
 
     /** {@inheritDoc} */
@@ -127,7 +127,7 @@ public class JGitScmProvider
     {
         // Note: I need to supply just 1 absolute path, but ScmFileSet won't let me without
         // a basedir (which isn't used here anyway), so use a dummy file.
-        GitInfoScmResult result = info( null, new ScmFileSet( new File( "" ), path ), null );
+    	InfoScmResult result = info( null, new ScmFileSet( new File( "" ), path ), null );
 
         if ( result.getInfoItems().size() != 1 )
         {
@@ -137,4 +137,14 @@ public class JGitScmProvider
 
         return ( (GitInfoItem) result.getInfoItems().get( 0 ) ).getURL();
     }
+
+    /** {@inheritDoc} */
+	protected GitCommand getBlameCommand() {
+		throw new UnsupportedOperationException("getBlameCommand");
+	}
+
+	/** {@inheritDoc} */
+	protected GitCommand getRemoteInfoCommand() {
+		throw new UnsupportedOperationException("getRemoteInfoCommand");
+	}
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
@@ -19,6 +19,8 @@ package org.apache.maven.scm.provider.git.jgit;
  * under the License.
  */
 
+import java.io.File;
+
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.command.info.InfoScmResult;
@@ -31,11 +33,10 @@ import org.apache.maven.scm.provider.git.jgit.command.changelog.JGitChangeLogCom
 import org.apache.maven.scm.provider.git.jgit.command.checkin.JGitCheckInCommand;
 import org.apache.maven.scm.provider.git.jgit.command.checkout.JGitCheckOutCommand;
 import org.apache.maven.scm.provider.git.jgit.command.diff.JGitDiffCommand;
+import org.apache.maven.scm.provider.git.jgit.command.list.JGitListCommand;
 import org.apache.maven.scm.provider.git.jgit.command.status.JGitStatusCommand;
 import org.apache.maven.scm.provider.git.jgit.command.tag.JGitTagCommand;
 import org.apache.maven.scm.repository.ScmRepositoryException;
-
-import java.io.File;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -114,7 +115,7 @@ public class JGitScmProvider
     /** {@inheritDoc} */
     protected GitCommand getListCommand()
     {
-    	throw new UnsupportedOperationException("getListCommand");
+    	return new JGitListCommand();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -101,8 +101,9 @@ public class JGitUtils {
 		config.setString("remote", "origin", "url", repository.getFetchUrl());
 		config.setString("remote", "origin", "pushURL", repository.getPushUrl());
 		// make sure we do not log any passwords to the output
-		logger.info("fetch url: " + repository.getFetchUrl().replace(repository.getPassword(), "******"));
-		logger.info("push url: " + repository.getPushUrl().replace(repository.getPassword(), "******"));
+		String password = repository.getPassword() != null ? repository.getPassword() : "";
+		logger.info("fetch url: " + repository.getFetchUrl().replace(password, "******"));
+		logger.info("push url: " + repository.getPushUrl().replace(password, "******"));
 		return getCredentials(repository);
 	}
 
@@ -118,7 +119,7 @@ public class JGitUtils {
 	 *         provider with
 	 */
 	public static CredentialsProvider getCredentials(GitScmProviderRepository repository) {
-		if (StringUtils.isNotBlank(repository.getUser())) {
+		if (StringUtils.isNotBlank(repository.getUser()) && StringUtils.isNotBlank(repository.getPassword())) {
 			return new UsernamePasswordCredentialsProvider(repository.getUser(), repository.getPassword());
 		}
 		return null;

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -2,6 +2,7 @@ package org.apache.maven.scm.provider.git.jgit.command;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.maven.scm.ScmBranch;
@@ -15,10 +16,16 @@ import org.apache.maven.scm.log.ScmLogger;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.lib.ProgressMonitor;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.lib.TextProgressMonitor;
 import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 //import org.eclipse.jgit.simple.SimpleRepository;
 //import org.eclipse.jgit.simple.StatusEntry;
 //import org.eclipse.jgit.simple.StatusEntry.IndexStatus;
@@ -44,187 +51,207 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
  * under the License.
  */
 
-
 /**
  * JGit SimpleRepository utility functions.
- *
+ * 
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  * @version $Id: JGitUtils.java 894145 2009-12-28 10:13:39Z struberg $
  */
-public class JGitUtils
-{
+public class JGitUtils {
 
 	private JGitUtils() {
 	}
-	
-    /**
-     * Construct a logging ProgressMonitor for all JGit operations.
-     * @param logger
-     * @return a ProgressMonitor for use 
-     */
-    public static ProgressMonitor getMonitor(ScmLogger logger) 
-    {
-        //X TODO write an own ProgressMonitor which logs to ScmLogger!
-        return new TextProgressMonitor();
-    }
 
-    
-    public static CredentialsProvider prepareSession(Git git, GitScmProviderRepository repository) {
+	/**
+	 * Construct a logging ProgressMonitor for all JGit operations.
+	 * 
+	 * @param logger
+	 * @return a ProgressMonitor for use
+	 */
+	public static ProgressMonitor getMonitor(ScmLogger logger) {
+		// X TODO write an own ProgressMonitor which logs to ScmLogger!
+		return new TextProgressMonitor();
+	}
+
+	public static CredentialsProvider prepareSession(ScmLogger logger, Git git, GitScmProviderRepository repository) {
 		StoredConfig config = git.getRepository().getConfig();
 		config.setString("remote", "origin", "url", repository.getFetchUrl());
 		config.setString("remote", "origin", "pushURL", repository.getPushUrl());
-		
+		logger.info("fetch url: " + repository.getFetchUrl());
+		logger.info("push url: " + repository.getPushUrl());
 		return getCredentials(repository);
-    }
-    
-    
-    public static CredentialsProvider getCredentials(GitScmProviderRepository repository) {
-    	if (StringUtils.isNotBlank(repository.getUser())) {
-			return new UsernamePasswordCredentialsProvider(repository.getUser(), repository.getPassword());	
+	}
+
+	public static CredentialsProvider getCredentials(GitScmProviderRepository repository) {
+		if (StringUtils.isNotBlank(repository.getUser())) {
+			return new UsernamePasswordCredentialsProvider(repository.getUser(), repository.getPassword());
 		}
 		return null;
-    }
-    
-//    
-//    /**
-//     * Translate a {@code FileStatus} in the matching {@code ScmFileStatus}.
-//     * 
-//     * @param status
-//     * @return the matching ScmFileStatus
-//     * @throws ScmException if the given Status cannot be translated
-//     */
-//    public static ScmFileStatus getScmFileStatus( StatusEntry status ) 
-//    throws ScmException 
-//    {
-//        IndexStatus is = status.getIndexStatus();
-//        RepoStatus  rs = status.getRepoStatus();
-//        
-//        if ( is.equals( IndexStatus.ADDED ) ) 
-//        {
-//            return ScmFileStatus.ADDED; 
-//        }
-//        else if ( is.equals( IndexStatus.UNCHANGED ) && rs.equals( RepoStatus.UNCHANGED ) ) 
-//        {
-//            return ScmFileStatus.CHECKED_IN; 
-//        }
-//        else if ( is.equals( IndexStatus.MODIFIED ) )
-//        {
-//            return ScmFileStatus.MODIFIED;
-//        }
-//        else if ( is.equals( IndexStatus.DELETED ) && rs.equals( RepoStatus.REMOVED ) )
-//        {
-//            return ScmFileStatus.DELETED;
-//        }
-//        else {
-//            return ScmFileStatus.UNKNOWN;
-//        }
-//        
-//        /*X 
-//        switch (status) {
-//            case UNMERGED:
-//                return ScmFileStatus.CONFLICT;
-//            case OTHER:
-//                return ScmFileStatus.ADDED;
-//            default:
-//                 
-//        }
-//        */
-//    }
-//    
-//    /**
-//     * Get the branch name from the ScmVersion
-//     * @param scmVersion
-//     * @return branch name if the ScmVersion indicates a branch, with taking <code>&quot;master&quot;</code>
-//     *         as default branch name. For tags <code>null</code> will be returned.
-//     */
-//    public static String getBranchName( ScmVersion scmVersion )
-//    {
-//        String branchName = "master";
-//        
-//        // we explicitly request branches, since tags will be handled differently in git
-//        if (scmVersion instanceof ScmTag) {
-//            return null;
-//        }
-//
-//        if (scmVersion instanceof ScmBranch)
-//        {
-//            branchName = scmVersion.getName();
-//        }
-//        
-//        return branchName;
-//    }
-//
-//    /**
-//     * get the tag name from the ScmVersion
-//     * @param scmVersion
-//     * @return tag name if the ScmVersion indicates a tag, <code>null</code> otherwise
-//     */
-//    public static String getTagName( ScmVersion scmVersion )
-//    {
-//        // we explicitly request branches, since tags will be handled differently in git
-//        if (scmVersion instanceof ScmTag) {
-//            return scmVersion.getName();
-//        }
-//
-//        return null;
-//    }
-//
-//    /**
-//     * Add all files of the given fileSet to the SimpleRepository.
-//     * This will make all relative paths be under the repositories base directory. 
-//     * 
-//     * @param srep
-//     * @param fileSet
-//     * @throws Exception
-//     */
-//    public static void addAllFiles( SimpleRepository srep, ScmFileSet fileSet ) 
-//    throws Exception 
-//    {
-//        @SuppressWarnings("unchecked")
-//        List<File> addFiles = fileSet.getFileList();
-//        if ( addFiles != null )
-//        {
-//            for ( File addFile : addFiles )
-//            {
-//                if ( !addFile.isAbsolute() )
-//                {
-//                    addFile = new File( fileSet.getBasedir(), addFile.getPath() );
-//                }
-//                
-//                srep.add( addFile, false );
-//            }
-//
-//        }
-//    }
-//
-//
-//    /**
-//     * Convert from List<StatusEntry> to List<ScmFile>
-//     * @param statusEntries
-//     * @param addUnknown if <code>false</code>, this function will not add files with 'unknown' status to the returned list 
-//     * @return list with ScmFiles ready for use in ScmResult and other maven-scm APIs
-//     * @throws ScmException 
-//     */
-//    public static List<ScmFile> getChangedFiles( List<StatusEntry> statusEntries, boolean addUnknown ) 
-//    throws ScmException 
-//    {
-//        if ( statusEntries == null ) 
-//        {
-//            return null;
-//        }
-//        
-//        List<ScmFile> changedFiles = new ArrayList<ScmFile>();
-//        
-//        for ( StatusEntry statusEntry : statusEntries ) 
-//        {
-//            ScmFileStatus status = getScmFileStatus( statusEntry );
-//            if ( addUnknown || !status.equals( ScmFileStatus.UNKNOWN ) )
-//            {
-//                changedFiles.add( new ScmFile( statusEntry.getFilePath(), status ) );
-//            }
-//            
-//        }
-//        return changedFiles;
-//    }
+	}
+
+	public static Iterable<PushResult> push(ScmLogger logger, Git git, GitScmProviderRepository repo, RefSpec refSpec) throws GitAPIException, InvalidRemoteException, TransportException {
+		CredentialsProvider credentials = JGitUtils.prepareSession(logger, git, repo);
+		Iterable<PushResult> pushResultList = git.push().setCredentialsProvider(credentials).setRefSpecs(refSpec).call();
+		for (PushResult pushResult : pushResultList) {
+			Collection<RemoteRefUpdate> ru = pushResult.getRemoteUpdates();
+			for (RemoteRefUpdate remoteRefUpdate : ru) {
+				logger.info(remoteRefUpdate.getStatus() + " - " + remoteRefUpdate.toString());
+			}
+		}
+		return pushResultList;
+	}
+
+	//
+	// /**
+	// * Translate a {@code FileStatus} in the matching {@code ScmFileStatus}.
+	// *
+	// * @param status
+	// * @return the matching ScmFileStatus
+	// * @throws ScmException if the given Status cannot be translated
+	// */
+	// public static ScmFileStatus getScmFileStatus( StatusEntry status )
+	// throws ScmException
+	// {
+	// IndexStatus is = status.getIndexStatus();
+	// RepoStatus rs = status.getRepoStatus();
+	//
+	// if ( is.equals( IndexStatus.ADDED ) )
+	// {
+	// return ScmFileStatus.ADDED;
+	// }
+	// else if ( is.equals( IndexStatus.UNCHANGED ) && rs.equals(
+	// RepoStatus.UNCHANGED ) )
+	// {
+	// return ScmFileStatus.CHECKED_IN;
+	// }
+	// else if ( is.equals( IndexStatus.MODIFIED ) )
+	// {
+	// return ScmFileStatus.MODIFIED;
+	// }
+	// else if ( is.equals( IndexStatus.DELETED ) && rs.equals(
+	// RepoStatus.REMOVED ) )
+	// {
+	// return ScmFileStatus.DELETED;
+	// }
+	// else {
+	// return ScmFileStatus.UNKNOWN;
+	// }
+	//
+	// /*X
+	// switch (status) {
+	// case UNMERGED:
+	// return ScmFileStatus.CONFLICT;
+	// case OTHER:
+	// return ScmFileStatus.ADDED;
+	// default:
+	//
+	// }
+	// */
+	// }
+	//
+	// /**
+	// * Get the branch name from the ScmVersion
+	// * @param scmVersion
+	// * @return branch name if the ScmVersion indicates a branch, with taking
+	// <code>&quot;master&quot;</code>
+	// * as default branch name. For tags <code>null</code> will be returned.
+	// */
+	// public static String getBranchName( ScmVersion scmVersion )
+	// {
+	// String branchName = "master";
+	//
+	// // we explicitly request branches, since tags will be handled differently
+	// in git
+	// if (scmVersion instanceof ScmTag) {
+	// return null;
+	// }
+	//
+	// if (scmVersion instanceof ScmBranch)
+	// {
+	// branchName = scmVersion.getName();
+	// }
+	//
+	// return branchName;
+	// }
+	//
+	// /**
+	// * get the tag name from the ScmVersion
+	// * @param scmVersion
+	// * @return tag name if the ScmVersion indicates a tag, <code>null</code>
+	// otherwise
+	// */
+	// public static String getTagName( ScmVersion scmVersion )
+	// {
+	// // we explicitly request branches, since tags will be handled differently
+	// in git
+	// if (scmVersion instanceof ScmTag) {
+	// return scmVersion.getName();
+	// }
+	//
+	// return null;
+	// }
+	//
+	// /**
+	// * Add all files of the given fileSet to the SimpleRepository.
+	// * This will make all relative paths be under the repositories base
+	// directory.
+	// *
+	// * @param srep
+	// * @param fileSet
+	// * @throws Exception
+	// */
+	// public static void addAllFiles( SimpleRepository srep, ScmFileSet fileSet
+	// )
+	// throws Exception
+	// {
+	// @SuppressWarnings("unchecked")
+	// List<File> addFiles = fileSet.getFileList();
+	// if ( addFiles != null )
+	// {
+	// for ( File addFile : addFiles )
+	// {
+	// if ( !addFile.isAbsolute() )
+	// {
+	// addFile = new File( fileSet.getBasedir(), addFile.getPath() );
+	// }
+	//
+	// srep.add( addFile, false );
+	// }
+	//
+	// }
+	// }
+	//
+	//
+	// /**
+	// * Convert from List<StatusEntry> to List<ScmFile>
+	// * @param statusEntries
+	// * @param addUnknown if <code>false</code>, this function will not add
+	// files with 'unknown' status to the returned list
+	// * @return list with ScmFiles ready for use in ScmResult and other
+	// maven-scm APIs
+	// * @throws ScmException
+	// */
+	// public static List<ScmFile> getChangedFiles( List<StatusEntry>
+	// statusEntries, boolean addUnknown )
+	// throws ScmException
+	// {
+	// if ( statusEntries == null )
+	// {
+	// return null;
+	// }
+	//
+	// List<ScmFile> changedFiles = new ArrayList<ScmFile>();
+	//
+	// for ( StatusEntry statusEntry : statusEntries )
+	// {
+	// ScmFileStatus status = getScmFileStatus( statusEntry );
+	// if ( addUnknown || !status.equals( ScmFileStatus.UNKNOWN ) )
+	// {
+	// changedFiles.add( new ScmFile( statusEntry.getFilePath(), status ) );
+	// }
+	//
+	// }
+	// return changedFiles;
+	// }
 
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -228,10 +228,7 @@ public class JGitUtils {
 		AddCommand add = git.add();
 		for (File file : fileSet.getFileList()) {
 			if (file.exists()) {
-				String path = file.getPath();
-				if (file.isAbsolute()) {
-					path = baseUri.relativize(new File(path).toURI()).getPath();
-				}
+				String path = relativize(baseUri, file);
 				add.addFilepattern(path);
 			}
 		}
@@ -249,13 +246,21 @@ public class JGitUtils {
 			// if a specific fileSet is given, we have to check if the file is
 			// really tracked
 			for (Iterator<File> itfl = fileSet.getFileList().iterator(); itfl.hasNext();) {
-				File f = (File) itfl.next();
-				if (f.toString().equals(scmfile.getPath())) {
+				String path = relativize(baseUri, itfl.next());
+				if (path.equals(scmfile.getPath())) {
 					changedFiles.add(scmfile);
 				}
 			}
 		}
 		return changedFiles;
+	}
+
+	private static String relativize(URI baseUri, File f) {
+		String path = f.getPath();
+		if (f.isAbsolute()) {
+			path = baseUri.relativize(new File(path).toURI()).getPath();
+		}
+		return path;
 	}
 
 	/**

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -12,12 +12,18 @@ import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.ScmTag;
 import org.apache.maven.scm.ScmVersion;
 import org.apache.maven.scm.log.ScmLogger;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ProgressMonitor;
+import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.lib.TextProgressMonitor;
-import org.eclipse.jgit.simple.SimpleRepository;
-import org.eclipse.jgit.simple.StatusEntry;
-import org.eclipse.jgit.simple.StatusEntry.IndexStatus;
-import org.eclipse.jgit.simple.StatusEntry.RepoStatus;
+import org.eclipse.jgit.transport.CredentialsProvider;
+//import org.eclipse.jgit.simple.SimpleRepository;
+//import org.eclipse.jgit.simple.StatusEntry;
+//import org.eclipse.jgit.simple.StatusEntry.IndexStatus;
+//import org.eclipse.jgit.simple.StatusEntry.RepoStatus;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -48,10 +54,13 @@ import org.eclipse.jgit.simple.StatusEntry.RepoStatus;
 public class JGitUtils
 {
 
+	private JGitUtils() {
+	}
+	
     /**
      * Construct a logging ProgressMonitor for all JGit operations.
      * @param logger
-     * @return a ProgressMonitor for use in {@code SimpleRepository}
+     * @return a ProgressMonitor for use 
      */
     public static ProgressMonitor getMonitor(ScmLogger logger) 
     {
@@ -60,145 +69,162 @@ public class JGitUtils
     }
 
     
-    /**
-     * Translate a {@code FileStatus} in the matching {@code ScmFileStatus}.
-     * 
-     * @param status
-     * @return the matching ScmFileStatus
-     * @throws ScmException if the given Status cannot be translated
-     */
-    public static ScmFileStatus getScmFileStatus( StatusEntry status ) 
-    throws ScmException 
-    {
-        IndexStatus is = status.getIndexStatus();
-        RepoStatus  rs = status.getRepoStatus();
-        
-        if ( is.equals( IndexStatus.ADDED ) ) 
-        {
-            return ScmFileStatus.ADDED; 
-        }
-        else if ( is.equals( IndexStatus.UNCHANGED ) && rs.equals( RepoStatus.UNCHANGED ) ) 
-        {
-            return ScmFileStatus.CHECKED_IN; 
-        }
-        else if ( is.equals( IndexStatus.MODIFIED ) )
-        {
-            return ScmFileStatus.MODIFIED;
-        }
-        else if ( is.equals( IndexStatus.DELETED ) && rs.equals( RepoStatus.REMOVED ) )
-        {
-            return ScmFileStatus.DELETED;
-        }
-        else {
-            return ScmFileStatus.UNKNOWN;
-        }
-        
-        /*X 
-        switch (status) {
-            case UNMERGED:
-                return ScmFileStatus.CONFLICT;
-            case OTHER:
-                return ScmFileStatus.ADDED;
-            default:
-                 
-        }
-        */
+    public static CredentialsProvider prepareSession(Git git, GitScmProviderRepository repository) {
+		StoredConfig config = git.getRepository().getConfig();
+		config.setString("remote", "origin", "url", repository.getFetchUrl());
+		config.setString("remote", "origin", "pushURL", repository.getPushUrl());
+		
+		return getCredentials(repository);
     }
     
-    /**
-     * Get the branch name from the ScmVersion
-     * @param scmVersion
-     * @return branch name if the ScmVersion indicates a branch, with taking <code>&quot;master&quot;</code>
-     *         as default branch name. For tags <code>null</code> will be returned.
-     */
-    public static String getBranchName( ScmVersion scmVersion )
-    {
-        String branchName = "master";
-        
-        // we explicitly request branches, since tags will be handled differently in git
-        if (scmVersion instanceof ScmTag) {
-            return null;
-        }
-
-        if (scmVersion instanceof ScmBranch)
-        {
-            branchName = scmVersion.getName();
-        }
-        
-        return branchName;
+    
+    public static CredentialsProvider getCredentials(GitScmProviderRepository repository) {
+    	if (StringUtils.isNotBlank(repository.getUser())) {
+			return new UsernamePasswordCredentialsProvider(repository.getUser(), repository.getPassword());	
+		}
+		return null;
     }
-
-    /**
-     * get the tag name from the ScmVersion
-     * @param scmVersion
-     * @return tag name if the ScmVersion indicates a tag, <code>null</code> otherwise
-     */
-    public static String getTagName( ScmVersion scmVersion )
-    {
-        // we explicitly request branches, since tags will be handled differently in git
-        if (scmVersion instanceof ScmTag) {
-            return scmVersion.getName();
-        }
-
-        return null;
-    }
-
-    /**
-     * Add all files of the given fileSet to the SimpleRepository.
-     * This will make all relative paths be under the repositories base directory. 
-     * 
-     * @param srep
-     * @param fileSet
-     * @throws Exception
-     */
-    public static void addAllFiles( SimpleRepository srep, ScmFileSet fileSet ) 
-    throws Exception 
-    {
-        @SuppressWarnings("unchecked")
-        List<File> addFiles = fileSet.getFileList();
-        if ( addFiles != null )
-        {
-            for ( File addFile : addFiles )
-            {
-                if ( !addFile.isAbsolute() )
-                {
-                    addFile = new File( fileSet.getBasedir(), addFile.getPath() );
-                }
-                
-                srep.add( addFile, false );
-            }
-
-        }
-    }
-
-
-    /**
-     * Convert from List<StatusEntry> to List<ScmFile>
-     * @param statusEntries
-     * @param addUnknown if <code>false</code>, this function will not add files with 'unknown' status to the returned list 
-     * @return list with ScmFiles ready for use in ScmResult and other maven-scm APIs
-     * @throws ScmException 
-     */
-    public static List<ScmFile> getChangedFiles( List<StatusEntry> statusEntries, boolean addUnknown ) 
-    throws ScmException 
-    {
-        if ( statusEntries == null ) 
-        {
-            return null;
-        }
-        
-        List<ScmFile> changedFiles = new ArrayList<ScmFile>();
-        
-        for ( StatusEntry statusEntry : statusEntries ) 
-        {
-            ScmFileStatus status = getScmFileStatus( statusEntry );
-            if ( addUnknown || !status.equals( ScmFileStatus.UNKNOWN ) )
-            {
-                changedFiles.add( new ScmFile( statusEntry.getFilePath(), status ) );
-            }
-            
-        }
-        return changedFiles;
-    }
+    
+//    
+//    /**
+//     * Translate a {@code FileStatus} in the matching {@code ScmFileStatus}.
+//     * 
+//     * @param status
+//     * @return the matching ScmFileStatus
+//     * @throws ScmException if the given Status cannot be translated
+//     */
+//    public static ScmFileStatus getScmFileStatus( StatusEntry status ) 
+//    throws ScmException 
+//    {
+//        IndexStatus is = status.getIndexStatus();
+//        RepoStatus  rs = status.getRepoStatus();
+//        
+//        if ( is.equals( IndexStatus.ADDED ) ) 
+//        {
+//            return ScmFileStatus.ADDED; 
+//        }
+//        else if ( is.equals( IndexStatus.UNCHANGED ) && rs.equals( RepoStatus.UNCHANGED ) ) 
+//        {
+//            return ScmFileStatus.CHECKED_IN; 
+//        }
+//        else if ( is.equals( IndexStatus.MODIFIED ) )
+//        {
+//            return ScmFileStatus.MODIFIED;
+//        }
+//        else if ( is.equals( IndexStatus.DELETED ) && rs.equals( RepoStatus.REMOVED ) )
+//        {
+//            return ScmFileStatus.DELETED;
+//        }
+//        else {
+//            return ScmFileStatus.UNKNOWN;
+//        }
+//        
+//        /*X 
+//        switch (status) {
+//            case UNMERGED:
+//                return ScmFileStatus.CONFLICT;
+//            case OTHER:
+//                return ScmFileStatus.ADDED;
+//            default:
+//                 
+//        }
+//        */
+//    }
+//    
+//    /**
+//     * Get the branch name from the ScmVersion
+//     * @param scmVersion
+//     * @return branch name if the ScmVersion indicates a branch, with taking <code>&quot;master&quot;</code>
+//     *         as default branch name. For tags <code>null</code> will be returned.
+//     */
+//    public static String getBranchName( ScmVersion scmVersion )
+//    {
+//        String branchName = "master";
+//        
+//        // we explicitly request branches, since tags will be handled differently in git
+//        if (scmVersion instanceof ScmTag) {
+//            return null;
+//        }
+//
+//        if (scmVersion instanceof ScmBranch)
+//        {
+//            branchName = scmVersion.getName();
+//        }
+//        
+//        return branchName;
+//    }
+//
+//    /**
+//     * get the tag name from the ScmVersion
+//     * @param scmVersion
+//     * @return tag name if the ScmVersion indicates a tag, <code>null</code> otherwise
+//     */
+//    public static String getTagName( ScmVersion scmVersion )
+//    {
+//        // we explicitly request branches, since tags will be handled differently in git
+//        if (scmVersion instanceof ScmTag) {
+//            return scmVersion.getName();
+//        }
+//
+//        return null;
+//    }
+//
+//    /**
+//     * Add all files of the given fileSet to the SimpleRepository.
+//     * This will make all relative paths be under the repositories base directory. 
+//     * 
+//     * @param srep
+//     * @param fileSet
+//     * @throws Exception
+//     */
+//    public static void addAllFiles( SimpleRepository srep, ScmFileSet fileSet ) 
+//    throws Exception 
+//    {
+//        @SuppressWarnings("unchecked")
+//        List<File> addFiles = fileSet.getFileList();
+//        if ( addFiles != null )
+//        {
+//            for ( File addFile : addFiles )
+//            {
+//                if ( !addFile.isAbsolute() )
+//                {
+//                    addFile = new File( fileSet.getBasedir(), addFile.getPath() );
+//                }
+//                
+//                srep.add( addFile, false );
+//            }
+//
+//        }
+//    }
+//
+//
+//    /**
+//     * Convert from List<StatusEntry> to List<ScmFile>
+//     * @param statusEntries
+//     * @param addUnknown if <code>false</code>, this function will not add files with 'unknown' status to the returned list 
+//     * @return list with ScmFiles ready for use in ScmResult and other maven-scm APIs
+//     * @throws ScmException 
+//     */
+//    public static List<ScmFile> getChangedFiles( List<StatusEntry> statusEntries, boolean addUnknown ) 
+//    throws ScmException 
+//    {
+//        if ( statusEntries == null ) 
+//        {
+//            return null;
+//        }
+//        
+//        List<ScmFile> changedFiles = new ArrayList<ScmFile>();
+//        
+//        for ( StatusEntry statusEntry : statusEntries ) 
+//        {
+//            ScmFileStatus status = getScmFileStatus( statusEntry );
+//            if ( addUnknown || !status.equals( ScmFileStatus.UNKNOWN ) )
+//            {
+//                changedFiles.add( new ScmFile( statusEntry.getFilePath(), status ) );
+//            }
+//            
+//        }
+//        return changedFiles;
+//    }
 
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -258,6 +258,28 @@ public class JGitUtils {
 		return changedFiles;
 	}
 
+	/**
+	 * Get a list of commits between two revisions.
+	 * 
+	 * @param repo
+	 *            the repository to work on
+	 * @param sortings
+	 *            sorting
+	 * @param fromRev
+	 *            start revision
+	 * @param toRev
+	 *            if null, falls back to head
+	 * @param fromDate
+	 *            from which date on
+	 * @param toDate
+	 *            until which date
+	 * @param maxLines
+	 *            max number of lines
+	 * @return a list of commits, might be empty, but never <code>null</code>
+	 * @throws IOException
+	 * @throws MissingObjectException
+	 * @throws IncorrectObjectTypeException
+	 */
 	public static List<RevCommit> getRevCommits(Repository repo, RevSort[] sortings, String fromRev, String toRev, Date fromDate, Date toDate, int maxLines) throws IOException, MissingObjectException, IncorrectObjectTypeException {
 		List<RevCommit> revs = new ArrayList<RevCommit>();
 		RevWalk walk = new RevWalk(repo);

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -77,8 +77,8 @@ public class JGitUtils {
 		StoredConfig config = git.getRepository().getConfig();
 		config.setString("remote", "origin", "url", repository.getFetchUrl());
 		config.setString("remote", "origin", "pushURL", repository.getPushUrl());
-		logger.info("fetch url: " + repository.getFetchUrl());
-		logger.info("push url: " + repository.getPushUrl());
+		logger.info("fetch url: " + repository.getFetchUrl().replace(repository.getPassword(), "******"));
+		logger.info("push url: " + repository.getPushUrl().replace(repository.getPassword(), "******"));
 		return getCredentials(repository);
 	}
 

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/add/JGitAddCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/add/JGitAddCommand.java
@@ -56,7 +56,7 @@ public class JGitAddCommand
 
         if ( fileSet.getFileList().isEmpty() )
         {
-            throw new ScmException( "You must provide at least one file/directory to add" );
+            throw new ScmException( "You must provide at least one file/directory to add (e.g. -Dincludes=...)" );
         }
         try
         {

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/add/JGitAddCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/add/JGitAddCommand.java
@@ -19,88 +19,48 @@ package org.apache.maven.scm.provider.git.jgit.command.add;
  * under the License.
  */
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
-import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.ScmResult;
 import org.apache.maven.scm.command.add.AbstractAddCommand;
 import org.apache.maven.scm.command.add.AddScmResult;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.command.GitCommand;
-import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
-import org.eclipse.jgit.api.AddCommand;
+import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.Status;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
+ * @author Dominik Bartholdi (imod)
  * @version $Id: JGitAddCommand.java 894145 2009-12-28 10:13:39Z struberg $
  */
-public class JGitAddCommand
-    extends AbstractAddCommand
-    implements GitCommand
-{
-    /** {@inheritDoc} */
-    protected ScmResult executeAddCommand( ScmProviderRepository repo, ScmFileSet fileSet, String message,
-                                           boolean binary )
-        throws ScmException
-    {
-        GitScmProviderRepository repository = (GitScmProviderRepository) repo;
+public class JGitAddCommand extends AbstractAddCommand implements GitCommand {
+	/** {@inheritDoc} */
+	protected ScmResult executeAddCommand(ScmProviderRepository repo, ScmFileSet fileSet, String message, boolean binary) throws ScmException {
 
-        if ( fileSet.getFileList().isEmpty() )
-        {
-            throw new ScmException( "You must provide at least one file/directory to add (e.g. -Dincludes=...)" );
-        }
-        try
-        {
-            Git git = Git.open(fileSet.getBasedir());
-            AddCommand add = git.add();
-            for (File file : fileSet.getFileList()) {
-				add.addFilepattern(file.getPath());	
+		if (fileSet.getFileList().isEmpty()) {
+			throw new ScmException("You must provide at least one file/directory to add (e.g. -Dincludes=...)");
+		}
+		try {
+			Git git = Git.open(fileSet.getBasedir());
+
+			List<ScmFile> addedFiles = JGitUtils.addAllFiles(git, fileSet);
+
+			if (getLogger().isDebugEnabled()) {
+				for (ScmFile scmFile : addedFiles) {
+					getLogger().info("added file: " + scmFile);
+				}
 			}
-            add.call();
-            
-            
-            // git-add doesn't show single files, but only summary
-            // so we must run git-status
-            
-            Status status = git.status().call();
-            Set<String> changed = status.getChanged();
-//            List<StatusEntry> entries = srep.status();
-            
 
-            List<ScmFile> changedFiles = new ArrayList<ScmFile>();
+			return new AddScmResult("JGit add", addedFiles);
 
-            // rewrite all detected files to now have status 'checked_in'
-            for ( String entry : changed )
-            {
-                ScmFile scmfile = new ScmFile( entry, ScmFileStatus.MODIFIED );
+		} catch (Exception e) {
+			throw new ScmException("JGit add failure!", e);
+		}
 
-                // if a specific fileSet is given, we have to check if the file is really tracked
-                for ( Iterator<File> itfl = fileSet.getFileList().iterator(); itfl.hasNext(); )
-                {
-                    File f = (File) itfl.next();
-                    if ( f.toString().equals( scmfile.getPath() ) )
-                    {
-                        changedFiles.add( scmfile );
-                    }
-                }
-            }
-            return new AddScmResult( "JGit add", changedFiles );
-            
-        }
-        catch ( Exception e )
-        {
-            throw new ScmException("JGit add failure!", e );
-        }
-        
-    }
+	}
 
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
@@ -1,7 +1,25 @@
 package org.apache.maven.scm.provider.git.jgit.command.branch;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.apache.maven.scm.ScmException;
@@ -17,10 +35,12 @@ import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
-import org.eclipse.jgit.transport.RemoteRefUpdate;
 
+/**
+ * 
+ * @author Dominik Bartholdi (imod)
+ */
 public class JGitBranchCommand extends AbstractBranchCommand implements GitCommand {
 
 	/** {@inheritDoc} */

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
@@ -1,0 +1,56 @@
+package org.apache.maven.scm.provider.git.jgit.command.branch;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmResult;
+import org.apache.maven.scm.command.branch.AbstractBranchCommand;
+import org.apache.maven.scm.command.branch.BranchScmResult;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.git.command.GitCommand;
+import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
+
+public class JGitBranchCommand extends AbstractBranchCommand implements GitCommand {
+
+	/** {@inheritDoc} */
+	@Override
+	protected ScmResult executeBranchCommand(ScmProviderRepository repo, ScmFileSet fileSet, String branch, String message) throws ScmException {
+		if (branch == null || StringUtils.isEmpty(branch.trim())) {
+			throw new ScmException("branch name must be specified");
+		}
+
+		if (!fileSet.getFileList().isEmpty()) {
+			throw new ScmException("This provider doesn't support branching subsets of a directory");
+		}
+
+		try {
+			Git git = Git.open(fileSet.getBasedir());
+			Ref branchRef = git.branchCreate().setName(branch).call();
+
+			if (repo.isPushChanges()) {
+				getLogger().info("push branch [" + branch + "] to remote...");
+				JGitUtils.push(getLogger(), git, (GitScmProviderRepository) repo, new RefSpec("refs/heads/" + branch));
+			}
+
+			List<ScmFile> taggedFiles = new ArrayList<ScmFile>();
+			// TODO list all branched files
+
+			return new BranchScmResult("JGit branch", taggedFiles);
+
+		} catch (Exception e) {
+			throw new ScmException("JGit branch failed!", e);
+		}
+	}
+
+}

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
@@ -56,7 +56,7 @@ public class JGitBranchCommand extends AbstractBranchCommand implements GitComma
 
 		try {
 			Git git = Git.open(fileSet.getBasedir());
-			Ref branchRef = git.branchCreate().setName(branch).call();
+			git.branchCreate().setName(branch).call();
 
 			if (repo.isPushChanges()) {
 				getLogger().info("push branch [" + branch + "] to remote...");

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
@@ -19,6 +19,13 @@ package org.apache.maven.scm.provider.git.jgit.command.changelog;
  * under the License.
  */
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.maven.scm.ChangeSet;
 import org.apache.maven.scm.ScmBranch;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
@@ -27,80 +34,256 @@ import org.apache.maven.scm.command.changelog.AbstractChangeLogCommand;
 import org.apache.maven.scm.command.changelog.ChangeLogScmResult;
 import org.apache.maven.scm.command.changelog.ChangeLogSet;
 import org.apache.maven.scm.provider.ScmProviderRepository;
-import org.apache.maven.scm.provider.git.GitChangeSet;
 import org.apache.maven.scm.provider.git.command.GitCommand;
-import org.eclipse.jgit.simple.ChangeEntry;
-import org.eclipse.jgit.simple.SimpleRepository;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevFlag;
+import org.eclipse.jgit.revwalk.RevSort;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.CommitTimeRevFilter;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
- * @version $Id: JGitChangeLogCommand.java 894145 2009-12-28 10:13:39Z struberg $
+ * @version $Id: JGitChangeLogCommand.java 894145 2009-12-28 10:13:39Z struberg
+ *          $
  */
-public class JGitChangeLogCommand
-    extends AbstractChangeLogCommand
-    implements GitCommand
-{
-    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss Z";
+public class JGitChangeLogCommand extends AbstractChangeLogCommand implements GitCommand {
+	private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss Z";
 
-    /** {@inheritDoc} */
-    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                          ScmVersion startVersion, ScmVersion endVersion,
-                                                          String datePattern )
-        throws ScmException
-    {
-        return executeChangeLogCommand( repo, fileSet, null, null, null, datePattern, startVersion, endVersion );
-    }
+	/** {@inheritDoc} */
+	protected ChangeLogScmResult executeChangeLogCommand(ScmProviderRepository repo, ScmFileSet fileSet, ScmVersion startVersion, ScmVersion endVersion, String datePattern) throws ScmException {
+		return executeChangeLogCommand(repo, fileSet, null, null, null, datePattern, startVersion, endVersion);
+	}
 
-    /** {@inheritDoc} */
-    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                          Date startDate, Date endDate, ScmBranch branch,
-                                                          String datePattern )
-        throws ScmException
-    {
-        return executeChangeLogCommand( repo, fileSet, startDate, endDate, branch, datePattern, null, null );
-    }
+	/** {@inheritDoc} */
+	protected ChangeLogScmResult executeChangeLogCommand(ScmProviderRepository repo, ScmFileSet fileSet, Date startDate, Date endDate, ScmBranch branch, String datePattern) throws ScmException {
+		return executeChangeLogCommand(repo, fileSet, startDate, endDate, branch, datePattern, null, null);
+	}
 
-    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                          Date startDate, Date endDate, ScmBranch branch,
-                                                          String datePattern, ScmVersion startVersion,
-                                                          ScmVersion endVersion )
-        throws ScmException
-    {
-        try
-        {
-            SimpleRepository srep = SimpleRepository.existing( fileSet.getBasedir() );
+	protected ChangeLogScmResult executeChangeLogCommand(ScmProviderRepository repo, ScmFileSet fileSet, Date startDate, Date endDate, ScmBranch branch, String datePattern, ScmVersion startVersion, ScmVersion endVersion) throws ScmException {
+		try {
+			Git git = Git.open(fileSet.getBasedir());
 
-            List<GitChangeSet> modifications = new ArrayList<GitChangeSet>();
-            
-            String startRev = startVersion != null ? startVersion.getName() : null;
-            String endRev   = endVersion != null ? endVersion.getName() : null;
-            
-            List<ChangeEntry> gitChanges = srep.whatchanged( null, startRev, endRev, startDate, endDate, -1 );
-            
-            for ( ChangeEntry change : gitChanges ) {
-                GitChangeSet scmChange = new GitChangeSet();
-                
-                scmChange.setAuthor( change.getAuthorName() );
-                scmChange.setComment( change.getBody() );
-                scmChange.setDate( change.getAuthorDate() );
-                //X TODO scmChange.setFiles( change.get )
-                
-                modifications.add( scmChange );
-            }
-            
-            ChangeLogSet changeLogSet = new ChangeLogSet( modifications, startDate, endDate );
-            changeLogSet.setStartVersion( startVersion );
-            changeLogSet.setEndVersion( endVersion );
-            
-            return new ChangeLogScmResult( "JGit changelog", changeLogSet );
-        }
-        catch ( Exception e )
-        {
-            throw new ScmException( "JGit changelog failure!", e );
-        }
-    }
+			List<ChangeSet> modifications = new ArrayList<ChangeSet>();
+
+			String startRev = startVersion != null ? startVersion.getName() : null;
+			String endRev = endVersion != null ? endVersion.getName() : null;
+
+			List<ChangeEntry> gitChanges = this.whatchanged(git.getRepository(), null, startRev, endRev, startDate, endDate, -1);
+
+			for (ChangeEntry change : gitChanges) {
+				ChangeSet scmChange = new ChangeSet();
+
+				scmChange.setAuthor(change.getAuthorName());
+				scmChange.setComment(change.getBody());
+				scmChange.setDate(change.getAuthorDate());
+				// X TODO scmChange.setFiles( change.get )
+
+				modifications.add(scmChange);
+			}
+
+			ChangeLogSet changeLogSet = new ChangeLogSet(modifications, startDate, endDate);
+			changeLogSet.setStartVersion(startVersion);
+			changeLogSet.setEndVersion(endVersion);
+
+			return new ChangeLogScmResult("JGit changelog", changeLogSet);
+		} catch (Exception e) {
+			throw new ScmException("JGit changelog failure!", e);
+		}
+	}
+
+	public List<ChangeEntry> whatchanged(Repository repo, RevSort[] sortings, String fromRev, String toRev, Date fromDate, Date toDate, int maxLines) throws MissingObjectException, IncorrectObjectTypeException, IOException {
+		List<ChangeEntry> changes = new ArrayList<ChangeEntry>();
+		List<RevCommit> revs = getRevCommits(repo, sortings, fromRev, toRev, fromDate, toDate, maxLines);
+
+		for (RevCommit c : revs) {
+			ChangeEntry ce = new ChangeEntry();
+
+			ce.setAuthorDate(c.getAuthorIdent().getWhen());
+			ce.setAuthorEmail(c.getAuthorIdent().getEmailAddress());
+			ce.setAuthorName(c.getAuthorIdent().getName());
+			ce.setCommitterDate(c.getCommitterIdent().getWhen());
+			ce.setCommitterEmail(c.getCommitterIdent().getEmailAddress());
+			ce.setCommitterName(c.getCommitterIdent().getName());
+
+			ce.setSubject(c.getShortMessage());
+			ce.setBody(c.getFullMessage());
+
+			ce.setCommitHash(c.getId().name());
+			ce.setTreeHash(c.getTree().getId().name());
+
+			// X TODO missing: file list
+
+			changes.add(ce);
+		}
+
+		return changes;
+	}
+
+	private List<RevCommit> getRevCommits(Repository repo, RevSort[] sortings, String fromRev, String toRev, Date fromDate, Date toDate, int maxLines) throws IOException, MissingObjectException, IncorrectObjectTypeException {
+		List<RevCommit> revs = new ArrayList<RevCommit>();
+		RevWalk walk = new RevWalk(repo);
+
+		ObjectId fromRevId = fromRev != null ? repo.resolve(fromRev) : null;
+		ObjectId toRevId = toRev != null ? repo.resolve(toRev) : null;
+
+		if (sortings == null || sortings.length == 0) {
+			sortings = new RevSort[] { RevSort.TOPO, RevSort.COMMIT_TIME_DESC };
+		}
+
+		for (final RevSort s : sortings) {
+			walk.sort(s, true);
+		}
+
+		if (fromDate != null && toDate != null) {
+			walk.setRevFilter(CommitTimeRevFilter.between(fromDate, toDate));
+		} else {
+			if (fromDate != null) {
+				walk.setRevFilter(CommitTimeRevFilter.after(fromDate));
+			}
+
+			if (toDate != null) {
+				walk.setRevFilter(CommitTimeRevFilter.before(toDate));
+			}
+		}
+
+		if (fromRevId != null) {
+			RevCommit c = walk.parseCommit(fromRevId);
+			c.add(RevFlag.UNINTERESTING);
+			RevCommit real = walk.parseCommit(c);
+			walk.markUninteresting(real);
+		}
+
+		if (toRevId != null) {
+			RevCommit c = walk.parseCommit(toRevId);
+			c.remove(RevFlag.UNINTERESTING);
+			RevCommit real = walk.parseCommit(c);
+			walk.markStart(real);
+		} else {
+			final ObjectId head = repo.resolve(Constants.HEAD);
+			if (head == null) {
+				throw new RuntimeException("Cannot resolve " + Constants.HEAD);
+			}
+			RevCommit real = walk.parseCommit(head);
+			walk.markStart(real);
+		}
+
+		int n = 0;
+		for (final RevCommit c : walk) {
+			n++;
+			if (maxLines != -1 && n > maxLines) {
+				break;
+			}
+
+			revs.add(c);
+		}
+		return revs;
+	}
+
+	public static final class ChangeEntry {
+		private String commitHash;
+		private String treeHash;
+		private String authorName;
+		private String authorEmail;
+		private Date authorDate;
+		private String committerName;
+		private String committerEmail;
+		private Date committerDate;
+		private String subject;
+		private String body;
+		private List<File> files;
+
+		public String getCommitHash() {
+			return commitHash;
+		}
+
+		public void setCommitHash(String commitHash) {
+			this.commitHash = commitHash;
+		}
+
+		public String getTreeHash() {
+			return treeHash;
+		}
+
+		public void setTreeHash(String treeHash) {
+			this.treeHash = treeHash;
+		}
+
+		public String getAuthorName() {
+			return authorName;
+		}
+
+		public void setAuthorName(String authorName) {
+			this.authorName = authorName;
+		}
+
+		public String getAuthorEmail() {
+			return authorEmail;
+		}
+
+		public void setAuthorEmail(String authorEmail) {
+			this.authorEmail = authorEmail;
+		}
+
+		public Date getAuthorDate() {
+			return authorDate;
+		}
+
+		public void setAuthorDate(Date authorDate) {
+			this.authorDate = authorDate;
+		}
+
+		public String getCommitterName() {
+			return committerName;
+		}
+
+		public void setCommitterName(String committerName) {
+			this.committerName = committerName;
+		}
+
+		public String getCommitterEmail() {
+			return committerEmail;
+		}
+
+		public void setCommitterEmail(String committerEmail) {
+			this.committerEmail = committerEmail;
+		}
+
+		public Date getCommitterDate() {
+			return committerDate;
+		}
+
+		public void setCommitterDate(Date committerDate) {
+			this.committerDate = committerDate;
+		}
+
+		public String getSubject() {
+			return subject;
+		}
+
+		public void setSubject(String subject) {
+			this.subject = subject;
+		}
+
+		public String getBody() {
+			return body;
+		}
+
+		public void setBody(String body) {
+			this.body = body;
+		}
+
+		public List<File> getFiles() {
+			return files;
+		}
+
+		public void setFiles(List<File> files) {
+			this.files = files;
+		}
+	}
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
@@ -39,17 +39,13 @@ import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.errors.MissingObjectException;
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevFlag;
 import org.eclipse.jgit.revwalk.RevSort;
-import org.eclipse.jgit.revwalk.RevWalk;
-import org.eclipse.jgit.revwalk.filter.CommitTimeRevFilter;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
+ * @author Dominik Bartholdi (imod)
  * @version $Id: JGitChangeLogCommand.java 894145 2009-12-28 10:13:39Z struberg
  *          $
  */

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
@@ -19,10 +19,14 @@ package org.apache.maven.scm.provider.git.jgit.command.checkin;
  * under the License.
  */
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
-import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.ScmVersion;
 import org.apache.maven.scm.command.checkin.AbstractCheckInCommand;
 import org.apache.maven.scm.command.checkin.CheckInScmResult;
@@ -30,98 +34,70 @@ import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.command.GitCommand;
 import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
-import org.eclipse.jgit.simple.SimpleRepository;
-import org.eclipse.jgit.simple.StatusEntry;
-import org.eclipse.jgit.simple.StatusEntry.IndexStatus;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.PushCommand;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  * @version $Id: JGitCheckInCommand.java 894145 2009-12-28 10:13:39Z struberg $
  */
-public class JGitCheckInCommand
-    extends AbstractCheckInCommand
-    implements GitCommand
-{
-    /** {@inheritDoc} */
-    protected CheckInScmResult executeCheckInCommand( ScmProviderRepository repo, ScmFileSet fileSet, String message,
-                                                      ScmVersion version )
-        throws ScmException
-    {
-        GitScmProviderRepository repository = (GitScmProviderRepository) repo;
+public class JGitCheckInCommand extends AbstractCheckInCommand implements GitCommand {
+	/** {@inheritDoc} */
+	protected CheckInScmResult executeCheckInCommand(ScmProviderRepository repo, ScmFileSet fileSet, String message, ScmVersion version) throws ScmException {
 
-        try 
-        {
-            SimpleRepository srep = SimpleRepository.existing( fileSet.getBasedir() );
-    
-            String branch = JGitUtils.getBranchName( version );
-            if ( !fileSet.getFileList().isEmpty() )
-            {
-                JGitUtils.addAllFiles( srep, fileSet );
-            }
-            else
-            {
-                // add all tracked files which are modified manually
-                List<StatusEntry> entries = srep.status();
-                for ( StatusEntry s : entries )
-                {
-                    if ( s.getIndexStatus().equals( IndexStatus.MODIFIED ) )
-                    {
-                        srep.add( new File( fileSet.getBasedir(), s.getFilePath() ), false );
-                    }
-                }
-            }
-            
-            // now read the status of all files which will be committed finally
-            List<StatusEntry> entries = srep.status();
-            
-            srep.commit( null, null, message );
-            srep.push( JGitUtils.getMonitor( getLogger() ), "origin", branch );
+		try {
+			Git git = Git.open(fileSet.getBasedir());
 
-            List<ScmFile> checkedInFiles = new ArrayList<ScmFile>( entries.size() );
-    
-            // parse files to now have status 'checked_in'
-            for ( StatusEntry entry : entries )
-            {
-                ScmFileStatus scmStatus = JGitUtils.getScmFileStatus( entry );
-                if ( scmStatus.equals( ScmFileStatus.ADDED )  || 
-                     scmStatus.equals( ScmFileStatus.DELETED) || 
-                     scmStatus.equals( ScmFileStatus.CHECKED_IN ) ) 
-                {
-                    // files which were previously added or deleted now got checked_in!
-                    ScmFile scmfile = new ScmFile( entry.getFilePath(), ScmFileStatus.CHECKED_IN );
-        
-                    if ( fileSet.getFileList().isEmpty() )
-                    {
-                        checkedInFiles.add( scmfile );
-                    }
-                    else
-                    {
-                        // if a specific fileSet is given, we have to check if the file is really tracked
-                        for ( Iterator<File> itfl = fileSet.getFileList().iterator(); itfl.hasNext(); )
-                        {
-                            File f =  itfl.next();
-                            if ( f.toString().equals( scmfile.getPath() ) )
-                            {
-                                checkedInFiles.add( scmfile );
-                            }
-        
-                        }
-                    }
-                }
-            }
-    
-            return new CheckInScmResult( "JGit checkin", checkedInFiles );
-        }
-        catch ( Exception e )
-        {
-            throw new ScmException("JGit checkin failure!", e );
-        }
-    }
+			if (!fileSet.getFileList().isEmpty()) {
+				AddCommand add = git.add();
+				for (File file : fileSet.getFileList()) {
+					add.addFilepattern(file.getPath());
+				}
+				add.call();
+			} else {
+				// add all tracked files which are modified manually
+				Set<String> changeds = git.status().call().getModified();
+				if (changeds.isEmpty()) {
+					// warn there is nothing to add
+				} else {
+					AddCommand add = git.add();
+					for (String changed : changeds) {
+						add.addFilepattern(changed);
+					}
+					add.call();
+				}
+			}
 
+			git.commit().setMessage(message).call();
+
+			if (repo.isPushChanges()) {
+				String branch = version != null ? version.getName() : null;
+				if (StringUtils.isBlank(branch)) {
+					branch = git.getRepository().getBranch();
+				}
+				RefSpec refSpec = new RefSpec("refs/heads/" + branch + ":" + "refs/heads/" + branch);
+
+				getLogger().info("push changes to remote... " + refSpec.toString());
+
+				CredentialsProvider credentials = JGitUtils.prepareSession(git, (GitScmProviderRepository) repo);
+				git.push().setCredentialsProvider(credentials).setRefSpecs(refSpec).call();
+			}
+
+			List<ScmFile> checkedInFiles = new ArrayList<ScmFile>();
+			// TODO get a list of the commited files
+
+			return new CheckInScmResult("JGit checkin", checkedInFiles);
+		} catch (Exception e) {
+			throw new ScmException("JGit checkin failure!", e);
+		}
+	}
 
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
@@ -84,11 +84,8 @@ public class JGitCheckInCommand extends AbstractCheckInCommand implements GitCom
 					branch = git.getRepository().getBranch();
 				}
 				RefSpec refSpec = new RefSpec("refs/heads/" + branch + ":" + "refs/heads/" + branch);
-
 				getLogger().info("push changes to remote... " + refSpec.toString());
-
-				CredentialsProvider credentials = JGitUtils.prepareSession(git, (GitScmProviderRepository) repo);
-				git.push().setCredentialsProvider(credentials).setRefSpecs(refSpec).call();
+				JGitUtils.push(getLogger(), git, (GitScmProviderRepository) repo, refSpec);
 			}
 
 			List<ScmFile> checkedInFiles = new ArrayList<ScmFile>();

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
@@ -43,74 +43,56 @@ import org.eclipse.jgit.transport.URIish;
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  * @version $Id: JGitCheckOutCommand.java 894145 2009-12-28 10:13:39Z struberg $
  */
-public class JGitCheckOutCommand
-    extends AbstractCheckOutCommand
-    implements GitCommand
-{
-    /**
-     * For git, the given repository is a remote one.
-     * We have to clone it first if the working directory does not contain a git repo yet,
-     * otherwise we have to git-pull it.
-     *
-     * {@inheritDoc}
-     */
-    protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
-        throws ScmException
-    {
-    	GitScmProviderRepository repository = (GitScmProviderRepository) repo;
+public class JGitCheckOutCommand extends AbstractCheckOutCommand implements GitCommand {
+	/**
+	 * For git, the given repository is a remote one. We have to clone it first
+	 * if the working directory does not contain a git repo yet, otherwise we
+	 * have to git-pull it.
+	 * 
+	 * {@inheritDoc}
+	 */
+	protected CheckOutScmResult executeCheckOutCommand(ScmProviderRepository repo, ScmFileSet fileSet, ScmVersion version, boolean recursive) throws ScmException {
+		GitScmProviderRepository repository = (GitScmProviderRepository) repo;
 
-        if ( GitScmProviderRepository.PROTOCOL_FILE.equals( repository.getFetchInfo().getProtocol() )
-            && repository.getFetchInfo().getPath().indexOf( fileSet.getBasedir().getPath() ) >= 0 )
-        {
-            throw new ScmException( "remote repository must not be the working directory" );
-        }
-        
-        try {
-            
-            ProgressMonitor monitor = JGitUtils.getMonitor( getLogger() );
-    
-            String branch = version.getName();
-            
-            if ( !fileSet.getBasedir().exists() || !( new File( fileSet.getBasedir(), ".git" ).exists() ) )
-            {
-                if ( fileSet.getBasedir().exists() )
-                {
-                    // git refuses to clone otherwise
-                    fileSet.getBasedir().delete();
-                }
-    
-                // no git repo seems to exist, let's clone the original repo
-                CredentialsProvider credentials = JGitUtils.getCredentials((GitScmProviderRepository) repo);
-                Git.cloneRepository().setURI(repository.getFetchUrl()).setCredentialsProvider(credentials).setBranchesToClone(Collections.singleton(branch)).setDirectory(fileSet.getBasedir().getParentFile()).setProgressMonitor(monitor).call();
-                
-            }
-            else
-            {
-                Git git = Git.open(fileSet.getBasedir());
-                // switch branch if we currently are not on the proper one
-                git.checkout().setName(branch).call();
-                
-                
-                URIish uri = new URIish(repository.getFetchUrl());
-                git.fetch().setRemote(repository.getFetchUrl()).call();
-                git.pull().call();
-            }
-            
-            List<ScmFile> listedFiles = new ArrayList<ScmFile>();
-            // TODO collect checkedout files
-//            List<StatusEntry> fileEntries = srep.status(true, false);
-//            for (StatusEntry entry : fileEntries)
-//            {
-//                listedFiles.add( new ScmFile(entry.getFilePath(), JGitUtils.getScmFileStatus( entry ) ) );
-//            }
-            
-            return new CheckOutScmResult("checkout via JGit", listedFiles );
-        }
-        catch (Exception e)
-        {
-            throw new ScmException( "JGit checkout failure!", e );
-        }
-    }
+		if (GitScmProviderRepository.PROTOCOL_FILE.equals(repository.getFetchInfo().getProtocol()) && repository.getFetchInfo().getPath().indexOf(fileSet.getBasedir().getPath()) >= 0) {
+			throw new ScmException("remote repository must not be the working directory");
+		}
+
+		try {
+
+			ProgressMonitor monitor = JGitUtils.getMonitor(getLogger());
+
+			String branch = version.getName();
+
+			if (!fileSet.getBasedir().exists() || !(new File(fileSet.getBasedir(), ".git").exists())) {
+				if (fileSet.getBasedir().exists()) {
+					// git refuses to clone otherwise
+					fileSet.getBasedir().delete();
+				}
+
+				// no git repo seems to exist, let's clone the original repo
+				CredentialsProvider credentials = JGitUtils.getCredentials((GitScmProviderRepository) repo);
+				getLogger().info("cloning [" + branch + "] to " + fileSet.getBasedir());
+				Git.cloneRepository().setURI(repository.getFetchUrl()).setCredentialsProvider(credentials).setBranchesToClone(Collections.singleton(branch)).setDirectory(fileSet.getBasedir()).setProgressMonitor(monitor).call();
+
+			} else {
+				Git git = Git.open(fileSet.getBasedir());
+				// switch branch if we currently are not on the proper one
+				getLogger().info("checkout [" + branch + "] to " + fileSet.getBasedir());
+				git.checkout().setName(branch).call();
+
+				URIish uri = new URIish(repository.getFetchUrl());
+				git.fetch().setRemote(repository.getFetchUrl()).call();
+				git.pull().call();
+			}
+
+			List<ScmFile> listedFiles = new ArrayList<ScmFile>();
+			// TODO collect checkedout files
+
+			return new CheckOutScmResult("checkout via JGit", listedFiles);
+		} catch (Exception e) {
+			throw new ScmException("JGit checkout failure!", e);
+		}
+	}
 
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
@@ -41,6 +41,7 @@ import org.eclipse.jgit.transport.URIish;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
+ * @author Dominik Bartholdi (imod)
  * @version $Id: JGitCheckOutCommand.java 894145 2009-12-28 10:13:39Z struberg $
  */
 public class JGitCheckOutCommand extends AbstractCheckOutCommand implements GitCommand {

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
@@ -1,0 +1,88 @@
+package org.apache.maven.scm.provider.git.jgit.command.diff;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmFileStatus;
+import org.apache.maven.scm.ScmResult;
+import org.apache.maven.scm.ScmVersion;
+import org.apache.maven.scm.command.diff.AbstractDiffCommand;
+import org.apache.maven.scm.command.diff.DiffScmResult;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.git.command.GitCommand;
+import org.eclipse.jgit.api.DiffCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffEntry.ChangeType;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.AbstractTreeIterator;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+
+public class JGitDiffCommand extends AbstractDiffCommand implements GitCommand {
+
+	@Override
+	protected DiffScmResult executeDiffCommand(ScmProviderRepository repository, ScmFileSet fileSet, ScmVersion startRevision, ScmVersion endRevision) throws ScmException {
+
+		try {
+			Git git = Git.open(fileSet.getBasedir());
+
+			OutputStream out = new ByteArrayOutputStream();
+			DiffCommand diff = git.diff().setOutputStream(out).setOldTree(getTreeIterator(git.getRepository(), startRevision.getName())).setNewTree(getTreeIterator(git.getRepository(), endRevision.getName()));
+			List<DiffEntry> entries = diff.call();
+			List<ScmFile> changedFiles = new ArrayList<ScmFile>();
+			
+			// TODO get differences 
+			Map<String, CharSequence> differences = new HashMap<String, CharSequence>();
+
+			for (DiffEntry diffEntry : entries) {
+				changedFiles.add(new ScmFile(diffEntry.getNewPath(), getFileStatusForModificationType(diffEntry.getChangeType())));
+			}
+
+			return new DiffScmResult(changedFiles, differences, out.toString(), new ScmResult("JGit diff", "diff", null, true));
+		} catch (Exception e) {
+			throw new ScmException("JGit diff failure!", e);
+		}
+	}
+
+	private ScmFileStatus getFileStatusForModificationType(ChangeType changeType) {
+		switch (changeType) {
+		case ADD:
+			return ScmFileStatus.ADDED;
+		case MODIFY:
+			return ScmFileStatus.MODIFIED;
+		case DELETE:
+			return ScmFileStatus.DELETED;
+		case RENAME:
+			return ScmFileStatus.RENAMED;
+		case COPY:
+			return ScmFileStatus.COPIED;
+		default:
+			return ScmFileStatus.UNKNOWN;
+		}
+	}
+
+	private AbstractTreeIterator getTreeIterator(Repository repo, String name) throws IOException {
+		final ObjectId id = repo.resolve(name);
+		if (id == null)
+			throw new IllegalArgumentException(name);
+		final CanonicalTreeParser p = new CanonicalTreeParser();
+		final ObjectReader or = repo.newObjectReader();
+		try {
+			p.reset(or, new RevWalk(repo).parseTree(id));
+			return p;
+		} finally {
+			or.release();
+		}
+	}
+}

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
@@ -11,18 +11,17 @@ import java.util.Map;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
-import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.ScmResult;
 import org.apache.maven.scm.ScmVersion;
 import org.apache.maven.scm.command.diff.AbstractDiffCommand;
 import org.apache.maven.scm.command.diff.DiffScmResult;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.command.GitCommand;
+import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jgit.api.DiffCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
-import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
@@ -61,29 +60,12 @@ public class JGitDiffCommand extends AbstractDiffCommand implements GitCommand {
 			Map<String, CharSequence> differences = new HashMap<String, CharSequence>();
 
 			for (DiffEntry diffEntry : entries) {
-				changedFiles.add(new ScmFile(diffEntry.getNewPath(), getFileStatusForModificationType(diffEntry.getChangeType())));
+				changedFiles.add(new ScmFile(diffEntry.getNewPath(), JGitUtils.getScmFileStatus(diffEntry.getChangeType())));
 			}
 
 			return new DiffScmResult(changedFiles, differences, out.toString(), new ScmResult("JGit diff", "diff", null, true));
 		} catch (Exception e) {
 			throw new ScmException("JGit diff failure!", e);
-		}
-	}
-
-	private ScmFileStatus getFileStatusForModificationType(ChangeType changeType) {
-		switch (changeType) {
-		case ADD:
-			return ScmFileStatus.ADDED;
-		case MODIFY:
-			return ScmFileStatus.MODIFIED;
-		case DELETE:
-			return ScmFileStatus.DELETED;
-		case RENAME:
-			return ScmFileStatus.RENAMED;
-		case COPY:
-			return ScmFileStatus.COPIED;
-		default:
-			return ScmFileStatus.UNKNOWN;
 		}
 	}
 

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
@@ -1,5 +1,24 @@
 package org.apache.maven.scm.provider.git.jgit.command.diff;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -30,6 +49,10 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 
+/**
+ * 
+ * @author Dominik Bartholdi (imod)
+ */
 public class JGitDiffCommand extends AbstractDiffCommand implements GitCommand {
 
 	@Override

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/list/JGitListCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/list/JGitListCommand.java
@@ -1,0 +1,68 @@
+package org.apache.maven.scm.provider.git.jgit.command.list;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmFileStatus;
+import org.apache.maven.scm.ScmVersion;
+import org.apache.maven.scm.command.list.AbstractListCommand;
+import org.apache.maven.scm.command.list.ListScmResult;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.git.command.GitCommand;
+import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.transport.CredentialsProvider;
+
+/**
+ * 
+ * @author Dominik Bartholdi (imod)
+ */
+public class JGitListCommand extends AbstractListCommand implements GitCommand {
+
+	@Override
+	protected ListScmResult executeListCommand(ScmProviderRepository repo, ScmFileSet fileSet, boolean recursive, ScmVersion scmVersion) throws ScmException {
+
+		try {
+			Git git = Git.open(fileSet.getBasedir());
+			CredentialsProvider credentials = JGitUtils.prepareSession(getLogger(), git, (GitScmProviderRepository) repo);
+
+			List<ScmFile> list = new ArrayList<ScmFile>();
+			Collection<Ref> lsResult = git.lsRemote().setCredentialsProvider(credentials).call();
+			for (Ref ref : lsResult) {
+				if (getLogger().isDebugEnabled()) {
+					getLogger().info(ref.getObjectId().getName() + "  " + ref.getTarget().getName());
+				}
+				list.add(new ScmFile(ref.getName(), ScmFileStatus.CHECKED_IN));
+			}
+
+			return new ListScmResult("JGit ls-remote", list);
+		} catch (Exception e) {
+			throw new ScmException("JGit ls-remote failure!", e);
+		}
+	}
+}

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
@@ -19,18 +19,20 @@ package org.apache.maven.scm.provider.git.jgit.command.status;
  * under the License.
  */
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.command.status.AbstractStatusCommand;
 import org.apache.maven.scm.command.status.StatusScmResult;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.command.GitCommand;
-import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
-import org.eclipse.jgit.simple.SimpleRepository;
-import org.eclipse.jgit.simple.StatusEntry;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.Status;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -46,11 +48,10 @@ public class JGitStatusCommand
     {
         try 
         {
-            SimpleRepository srep = SimpleRepository.existing( fileSet.getBasedir() );
-            
-            List<StatusEntry> entries = srep.status();
-            List<ScmFile> changedFiles = JGitUtils.getChangedFiles( entries, false );
-            
+        	Git git = Git.open(fileSet.getBasedir());
+        	Status status = git.status().call();
+        	List<ScmFile> changedFiles = getFileStati(status);
+        	
             return new StatusScmResult( "JGit status", changedFiles );
         }
         catch ( Exception e )
@@ -58,4 +59,20 @@ public class JGitStatusCommand
             throw new ScmException("JGit status failure!", e );
         }
     }
+
+	private List<ScmFile> getFileStati(Status status) {
+		List<ScmFile> all = new ArrayList<ScmFile>();
+		addAsScmFiles(all, status.getAdded(), ScmFileStatus.ADDED);
+		addAsScmFiles(all, status.getChanged(), ScmFileStatus.UPDATED);
+		addAsScmFiles(all, status.getConflicting(), ScmFileStatus.CONFLICT);
+		addAsScmFiles(all, status.getModified(), ScmFileStatus.MODIFIED);
+		addAsScmFiles(all, status.getRemoved(), ScmFileStatus.DELETED);
+		return all;
+	}
+	
+	private void addAsScmFiles(Collection<ScmFile> all, Collection<String> files, ScmFileStatus status){
+		for (String f : files) {
+			all.add(new ScmFile(f, status));
+		}
+	}
 }

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
@@ -36,6 +36,7 @@ import org.eclipse.jgit.api.Status;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
+ * @author Dominik Bartholdi (imod)
  * @version $Id: JGitStatusCommand.java 894145 2009-12-28 10:13:39Z struberg $
  */
 public class JGitStatusCommand

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/tag/JGitTagCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/tag/JGitTagCommand.java
@@ -36,11 +36,11 @@ import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.RefSpec;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
+ * @author Dominik Bartholdi (imod)
  * @version $Id $
  */
 public class JGitTagCommand extends AbstractTagCommand implements GitCommand {

--- a/src/main/java/org/apache/maven/scm/provider/git/jgit/command/tag/JGitTagCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/git/jgit/command/tag/JGitTagCommand.java
@@ -68,12 +68,7 @@ public class JGitTagCommand extends AbstractTagCommand implements GitCommand {
 
 			if (repo.isPushChanges()) {
 				getLogger().info("push tag [" + tag + "] to remote...");
-				CredentialsProvider credentials = JGitUtils.prepareSession(git, (GitScmProviderRepository) repo);
-
-				// and now push the tag to the origin repository
-				RefSpec refSpec = new RefSpec("refs/tags/" + tag);
-				git.push().setCredentialsProvider(credentials).setRefSpecs(refSpec).call();
-
+				JGitUtils.push(getLogger(), git, (GitScmProviderRepository) repo, new RefSpec("refs/tags/" + tag));
 			}
 
 			// search for the tagged files


### PR DESCRIPTION
This PR updates the provider to the newest jgit version.
The provider now supports the maven-release-plugin and and should be ready for a first release. 
